### PR TITLE
feat: Adding candidate and relationship btw OTel and  kiness delivery stream

### DIFF
--- a/relationships/candidates/AWSKINESISDELIVERYSTREAM.yml
+++ b/relationships/candidates/AWSKINESISDELIVERYSTREAM.yml
@@ -1,0 +1,16 @@
+category: AWSKINESISDELIVERYSTREAM
+lookups:
+  - entityTypes:
+      - domain: INFRA
+        type: AWSKINESISDELIVERYSTREAM
+    tags:
+      matchingMode: ALL
+      predicates:
+        - tagKeys: ["aws.arn"]
+          field: cloudResourceId
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: AWSKINESISDELIVERYSTREAM

--- a/relationships/synthesis/EXT-SERVICE-to-INFRA-KINESISDELIVERYSTREAM.yml
+++ b/relationships/synthesis/EXT-SERVICE-to-INFRA-KINESISDELIVERYSTREAM.yml
@@ -1,0 +1,10 @@
+relationships:
+  - name: extServiceCallsInfraKinesisDeliveryStream
+    version: "1"
+    origins:
+      - Distributed Tracing
+    conditions:
+      - attribute: eventType
+        anyOf: [ "Span" ]
+      - attribute: rpc.service
+        anyOf: [ "kinesis" ]


### PR DESCRIPTION
### Relevant information

We are establishing a relationship between OTel and AWS Kinesis delivery Stream by using the ARN as the matching criterion. Users or customers from the OTel service need to manually send the ARN within the cloud.resource_id span attribute.

On the Cloud Monitoring platform side, we are associating tags with the aws.Arn for AWS Kinesis firehouse delivery streams, ensuring that the collector.name is equal to cloudwatch-metric-streams.

The ARN is formatted as follows for a function: arn:${realm}:kinesis:${region}:${accountId}:stream/${StreamName}

### Checklist

* [ ] I've read the guidelines and understand the acceptance criteria.
* [ ] The value of the attribute marked as `identifier` will be unique and valid. 
* [ ] I've confirmed that my entity type wasn't already defined. If it is I'm providing an explanation above.
